### PR TITLE
Bugfix: no files downloaded when overwrite=False

### DIFF
--- a/rf100vl/dataset.py
+++ b/rf100vl/dataset.py
@@ -23,7 +23,6 @@ class RF100VlDataset:
         return f"RF100VLDataset(name={self.name}, category={self.category})"
 
     def download(self, path: str, model_format: str = "coco", overwrite: bool = True):
-        os.makedirs(path, exist_ok=True)
         versions: List[Version] = self.rf_project.versions()
         latest_version: Version = max(versions, key=lambda v: v.id)
         dataset =latest_version.download(

--- a/rf100vl/dataset.py
+++ b/rf100vl/dataset.py
@@ -66,7 +66,7 @@ class RF100VlDataset:
 
         # confirm if category 0 is none
         if data_ann["categories"][0]["supercategory"] != "none":
-            return
+            return data_ann
 
         new_data_ann["categories"] = [
             {

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("README.md", "r", encoding="utf-8") as f:
 
 setup(
     name="rf100vl",
-    version="1.1.0",
+    version="1.1.1",
     description="RF100-VL Dataset Interface",
     author="Roboflow, Inc.",
     author_email="peter@roboflow.com",


### PR DESCRIPTION
## What does this PR do?

<!-- Provide a clear and concise description of the changes -->

Currently `RF100VlDataset.download()` creates the target directory before calling `latest_version.download()`. The roboflow SDK's `Version.download()` with `overwrite=False` checks whether the destination directory already exists — if it does, it assumes the dataset was already downloaded and skips the actual download. Since `Version.download()` already handles directory creation, we can just remove it from `RF100VlDataset.download()` to fix the issue

## Type of Change

<!-- Please select one and delete the others, or describe if Other -->

- Bug fix (non-breaking change that fixes an issue)

## Testing

<!-- Describe how you tested your changes -->

- [x] I have tested this change locally
- [ ] I have added/updated tests for this change

**Test details:**
<!-- Describe what tests were added/updated and what they cover -->

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation accordingly (if applicable)

## Additional Context

<!-- Add any other context, screenshots, or notes about the PR here -->
