### PR TITLE
Add single-index helpers for fan-out training jobs

### DIFF
--- a/rf100vl/__init__.py
+++ b/rf100vl/__init__.py
@@ -7,4 +7,6 @@ from rf100vl.roboflow100vl import (
     download_rf100vl,
     download_rf20vl_fsod,
     download_rf20vl_full,
+    get_rf100vl_dataset_by_index,
+    download_rf100vl_index,
 )

--- a/rf100vl/roboflow100vl.py
+++ b/rf100vl/roboflow100vl.py
@@ -101,3 +101,64 @@ def download_rf20vl_full(path: str, model_format: str = "coco", overwrite: bool 
     rf20vl_full_projects = get_rf20vl_full_projects(api_key)
     rf20vl_full_projects.download(path, model_format, overwrite)
     return rf20vl_full_projects
+
+
+# ---------------------------------------------------------------------------
+# Single-index helpers — pick the i-th rf100-vl dataset deterministically.
+#
+# Useful in fan-out training jobs where each pod gets a JOB_COMPLETION_INDEX
+# and needs to fetch just one dataset (downloading all 100 in every pod is
+# wasteful and flaky). The DatasetList from get_rf100vl_projects() is already
+# sorted by name, so `[i]` is stable across runs.
+# ---------------------------------------------------------------------------
+
+_PROJECT_FETCHERS = {
+    "rf100vl": get_rf100vl_projects,
+    "rf100vl_fsod": get_rf100vl_fsod_projects,
+    "rf20vl_full": get_rf20vl_full_projects,
+    "rf20vl_fsod": get_rf20vl_fsod_projects,
+}
+
+
+def get_rf100vl_dataset_by_index(
+    index: int,
+    *,
+    variant: str = "rf100vl",
+    api_key: Optional[str] = None,
+) -> "RF100VlDataset":
+    """Return the i-th dataset in the chosen rf100-vl variant.
+
+    Parameters
+    ----------
+    index : int
+        Zero-based index, sorted alphabetically by project name.
+    variant : str
+        One of ``rf100vl`` (default), ``rf100vl_fsod``, ``rf20vl_full``, ``rf20vl_fsod``.
+    api_key : str, optional
+        Roboflow API key. Falls back to ``ROBOFLOW_API_KEY`` env var.
+    """
+    fetcher = _PROJECT_FETCHERS.get(variant)
+    if fetcher is None:
+        raise ValueError(
+            f"unknown variant {variant!r}; expected one of {sorted(_PROJECT_FETCHERS)}"
+        )
+    datasets = fetcher(api_key)
+    n = len(datasets)
+    if not 0 <= index < n:
+        raise IndexError(f"variant {variant!r} has {n} datasets; index {index} out of range")
+    return datasets[index]
+
+
+def download_rf100vl_index(
+    index: int,
+    path: str,
+    *,
+    variant: str = "rf100vl",
+    model_format: str = "coco",
+    overwrite: bool = True,
+    api_key: Optional[str] = None,
+) -> "RF100VlDataset":
+    """Download just the i-th dataset to ``path``. Returns the materialized dataset."""
+    dataset = get_rf100vl_dataset_by_index(index, variant=variant, api_key=api_key)
+    dataset.download(path, model_format=model_format, overwrite=overwrite)
+    return dataset


### PR DESCRIPTION
## Summary
- New `get_rf100vl_dataset_by_index(i, variant=\"rf100vl\", api_key=None)` returns just the i-th dataset.
- New `download_rf100vl_index(i, path, variant=...)` downloads only that one dataset.
- Supported variants: `rf100vl` (default), `rf100vl_fsod`, `rf20vl_full`, `rf20vl_fsod`.

## Why
Drives the new \"fan-out\" mode in [roboflow/ml-infra](https://github.com/roboflow/ml-infra): an indexed k8s Job launches N pods (default 100), each with a unique `JOB_COMPLETION_INDEX`. With the existing API every pod has to materialize all 100 projects just to pick one, which is slow and prone to transient failures. The new helpers fetch one project.

Order is deterministic because `DatasetList` already sorts projects by name.

## Test plan
- [ ] \`python -c \"from rf100vl import get_rf100vl_dataset_by_index; d = get_rf100vl_dataset_by_index(0); print(d.name)\"\` returns the alphabetically-first project.
- [ ] \`python -c \"from rf100vl import download_rf100vl_index; download_rf100vl_index(0, '/tmp/rf100-0')\"\` downloads exactly one dataset.
- [ ] Invalid variant raises \`ValueError\` listing the supported variants.
- [ ] Out-of-range index raises \`IndexError\` with the dataset count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)