### PR TITLE
Add PyPI release workflow (OIDC) and bump to 1.1.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,52 @@
+name: Release to PyPI
+
+on:
+  push:
+    tags:
+      - "v*"
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build distributions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install build tooling
+        run: python -m pip install --upgrade build
+
+      - name: Build sdist and wheel
+        run: python -m build
+
+      - name: Upload distribution artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    name: Publish to PyPI (Trusted Publishing / OIDC)
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/rf100vl
+    permissions:
+      id-token: write
+    steps:
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("README.md", "r", encoding="utf-8") as f:
 
 setup(
     name="rf100vl",
-    version="1.1.1",
+    version="1.1.2",
     description="RF100-VL Dataset Interface",
     author="Roboflow, Inc.",
     author_email="peter@roboflow.com",


### PR DESCRIPTION
## Summary
- Add `.github/workflows/release.yml` that builds sdist+wheel and publishes to PyPI via OIDC Trusted Publishing (no API token needed)
- Triggers on `v*` tag push, GitHub Release publish, or manual `workflow_dispatch`
- Bump version `1.1.1` → `1.1.2`

## One-time setup required before first release
1. On PyPI: https://pypi.org/manage/project/rf100vl/settings/publishing/ → add Trusted Publisher with owner=`roboflow`, repo=`rf100-vl`, workflow=`release.yml`, environment=`pypi`
2. In GitHub repo Settings → Environments, create environment `pypi`

## Releasing
After merging: `git tag v1.1.2 && git push --tags` (or cut a GitHub Release).

## Test plan
- [ ] PyPI trusted publisher configured
- [ ] `pypi` environment exists in GitHub settings
- [ ] Tag `v1.1.2` triggers workflow and publishes to PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)