### PR TITLE
feat(cli): add Fire-based CLI for dataset downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Flags:
 | `dataset` | `rf100vl` or `rf20vl` (positional) |
 | `path` | download destination (positional) |
 | `--fsod` | use the few-shot object detection variant |
-| `--index N` | download only the N-th dataset in the variant, instead of all |
+| `--index N` | download only dataset index N in the variant (zero-based; 0 = first dataset), instead of all |
 | `--model_format` | annotation format, default `coco` |
 | `--overwrite` | overwrite existing files, default `True` |
 | `--api_key` | Roboflow API key, defaults to `ROBOFLOW_API_KEY` env var |
@@ -106,7 +106,7 @@ Examples:
 rf100vl download rf100vl ./data                 # RF100-VL, full
 rf100vl download rf100vl ./data --fsod           # RF100-VL-FSOD
 rf100vl download rf20vl ./data --fsod            # RF20-VL-FSOD
-rf100vl download rf100vl ./data --index 3        # single dataset by index
+rf100vl download rf100vl ./data --index 0        # first dataset by index
 ```
 
 ## CVPR 2025 Workshop Challenge: Few-Shot Object Detection from Annotator Instructions

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ Neehar Peri <sup>2</sup>
 </div>
 </div>
 
-
 Introduced in the paper "[Roboflow 100-VL: A Multi-Domain Object Detection Benchmark for Vision-Language Models](https://arxiv.org/pdf/2505.20612)", RF100-VL is a large-scale collection of 100 multi-modal datasets with diverse concepts not commonly found in VLM pre-training.
 
 The benchmark includes images, with corresponding annotations, from seven domains: flora and fauna, sport, industry, document processing, laboratory imaging, aerial imagery, and miscellaneous datasets related to various use cases for which detection models are commonly used.
@@ -54,16 +53,16 @@ export ROBOFLOW_API_KEY=YOUR_KEY
 
 Several helper functions are available to download RF100-VL and its subsets. These are split up into two categories: functions that retrieve Dataset objects with the name of each project and its category. (that start with `get_`), and data downloaders (that start with `download_`).
 
-| Data Loader Name               | Dataset Name           |
+| Data Loader Name | Dataset Name |
 |--------------------------------|------------------------|
-| `get_rf100vl_fsod_projects`      | RF100-VL-FSOD          |
-| `get_rf100vl_projects`           | RF100-VL               |
-| `get_rf20vl_fsod_projects`       | RF20-VL-FSOD           |
-| `get_rf20vl_full_projects`       | RF20-VL           |
-| `download_rf100vl_fsod`          | RF100-VL-FSOD          |
-| `download_rf100vl`               | RF100-VL               |
-| `download_rf20vl_fsod`           | RF20-VL-FSOD           |
-| `download_rf20vl_full`           | RF20-VL           |
+| `get_rf100vl_fsod_projects` | RF100-VL-FSOD |
+| `get_rf100vl_projects` | RF100-VL |
+| `get_rf20vl_fsod_projects` | RF20-VL-FSOD |
+| `get_rf20vl_full_projects` | RF20-VL |
+| `download_rf100vl_fsod` | RF100-VL-FSOD |
+| `download_rf100vl` | RF100-VL |
+| `download_rf20vl_fsod` | RF20-VL-FSOD |
+| `download_rf20vl_full` | RF20-VL |
 
 Each dataset object has its own `download` method.
 
@@ -76,6 +75,39 @@ download_rf100vl(path="./rf100-vl/")
 ```
 
 The datasets will be downloaded in COCO JSON format to a directory called `rf100-vl`. Every dataset will be in its own sub-folder.
+
+### CLI
+
+A command-line downloader is available via the optional `cli` extra:
+
+```
+pip install "rf100vl[cli]"
+```
+
+```
+rf100vl download rf100vl ./rf100-vl/
+```
+
+Flags:
+
+| Flag | Description |
+|------|-------------|
+| `dataset` | `rf100vl` or `rf20vl` (positional) |
+| `path` | download destination (positional) |
+| `--fsod` | use the few-shot object detection variant |
+| `--index N` | download only the N-th dataset in the variant, instead of all |
+| `--model_format` | annotation format, default `coco` |
+| `--overwrite` | overwrite existing files, default `True` |
+| `--api_key` | Roboflow API key, defaults to `ROBOFLOW_API_KEY` env var |
+
+Examples:
+
+```
+rf100vl download rf100vl ./data                 # RF100-VL, full
+rf100vl download rf100vl ./data --fsod           # RF100-VL-FSOD
+rf100vl download rf20vl ./data --fsod            # RF20-VL-FSOD
+rf100vl download rf100vl ./data --index 3        # single dataset by index
+```
 
 ## CVPR 2025 Workshop Challenge: Few-Shot Object Detection from Annotator Instructions
 
@@ -132,11 +164,11 @@ Submit a zip file with pickle files for each dataset. The name of each pickle fi
 ]
 ```
 
-We've provided a [sample submission](https://drive.google.com/file/d/1Pp8oAYMMnCxTzFa078NS3CuzdNlIEVzp/view) for your reference. Submissions should be uploaded to our [EvalAI server](https://eval.ai/web/challenges/challenge-page/2459/overview). 
+We've provided a [sample submission](https://drive.google.com/file/d/1Pp8oAYMMnCxTzFa078NS3CuzdNlIEVzp/view) for your reference. Submissions should be uploaded to our [EvalAI server](https://eval.ai/web/challenges/challenge-page/2459/overview).
 
 ### Official Baseline
 
-We pre-train Detic on ImageNet21-K, COCO Captions, and LVIS. We evaluate this pre-trained model zero-shot on the datasets in RF20-VL. 
+We pre-train Detic on ImageNet21-K, COCO Captions, and LVIS. We evaluate this pre-trained model zero-shot on the datasets in RF20-VL.
 
 Our baseline code is available [here](https://github.com/anishmadan23/foundational_fsod/tree/fsod_rf20vl?tab=readme-ov-file).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,9 +22,15 @@ dependencies = [
     "roboflow",
 ]
 
+[project.optional-dependencies]
+cli = ["fire"]
+
 [project.urls]
 Homepage = "https://github.com/roboflow/rf100-vl"
 Repository = "https://github.com/roboflow/rf100-vl"
+
+[project.scripts]
+rf100vl = "rf100vl.__main__:main"
 
 [tool.setuptools.packages.find]
 include = ["rf100vl*"]

--- a/rf100vl/__init__.py
+++ b/rf100vl/__init__.py
@@ -1,12 +1,25 @@
 from rf100vl.roboflow100vl import (
+    download_rf100vl,
+    download_rf100vl_fsod,
+    download_rf100vl_index,
+    download_rf20vl_fsod,
+    download_rf20vl_full,
+    get_rf100vl_dataset_by_index,
     get_rf100vl_fsod_projects,
     get_rf100vl_projects,
     get_rf20vl_fsod_projects,
     get_rf20vl_full_projects,
-    get_rf100vl_dataset_by_index,
-    download_rf100vl_fsod,
-    download_rf100vl,
-    download_rf20vl_fsod,
-    download_rf20vl_full,
-    download_rf100vl_index,
 )
+
+__all__ = [
+    "get_rf100vl_fsod_projects",
+    "get_rf100vl_projects",
+    "get_rf20vl_fsod_projects",
+    "get_rf20vl_full_projects",
+    "get_rf100vl_dataset_by_index",
+    "download_rf100vl_fsod",
+    "download_rf100vl",
+    "download_rf20vl_fsod",
+    "download_rf20vl_full",
+    "download_rf100vl_index",
+]

--- a/rf100vl/__init__.py
+++ b/rf100vl/__init__.py
@@ -3,10 +3,10 @@ from rf100vl.roboflow100vl import (
     get_rf100vl_projects,
     get_rf20vl_fsod_projects,
     get_rf20vl_full_projects,
+    get_rf100vl_dataset_by_index,
     download_rf100vl_fsod,
     download_rf100vl,
     download_rf20vl_fsod,
     download_rf20vl_full,
-    get_rf100vl_dataset_by_index,
     download_rf100vl_index,
 )

--- a/rf100vl/__main__.py
+++ b/rf100vl/__main__.py
@@ -1,0 +1,65 @@
+from typing import Optional
+
+from rf100vl import (
+    download_rf100vl,
+    download_rf100vl_fsod,
+    download_rf100vl_index,
+    download_rf20vl_fsod,
+    download_rf20vl_full,
+)
+
+_FULL_DOWNLOADERS = {
+    "rf100vl": download_rf100vl,
+    "rf20vl": download_rf20vl_full,
+}
+_FSOD_DOWNLOADERS = {
+    "rf100vl": download_rf100vl_fsod,
+    "rf20vl": download_rf20vl_fsod,
+}
+_INDEX_VARIANTS = {
+    ("rf100vl", False): "rf100vl",
+    ("rf100vl", True): "rf100vl_fsod",
+    ("rf20vl", False): "rf20vl_full",
+    ("rf20vl", True): "rf20vl_fsod",
+}
+
+
+def download(
+    dataset: str,
+    path: str,
+    fsod: bool = False,
+    index: Optional[int] = None,
+    model_format: str = "coco",
+    overwrite: bool = True,
+    api_key: Optional[str] = None,
+) -> None:
+    """Download an rf100-vl dataset.
+
+    dataset: "rf100vl" or "rf20vl"
+    fsod: use the few-shot object detection variant
+    index: download only the i-th dataset in the variant, instead of all
+    """
+    if dataset not in _FULL_DOWNLOADERS:
+        raise ValueError(f"unknown dataset {dataset!r}; expected one of {sorted(_FULL_DOWNLOADERS)}")
+
+    if index is not None:
+        variant = _INDEX_VARIANTS[(dataset, fsod)]
+        download_rf100vl_index(
+            index, path, variant=variant, model_format=model_format, overwrite=overwrite, api_key=api_key
+        )
+        return
+
+    downloader = (_FSOD_DOWNLOADERS if fsod else _FULL_DOWNLOADERS)[dataset]
+    downloader(path, model_format=model_format, overwrite=overwrite, api_key=api_key)
+
+
+def main() -> None:
+    try:
+        import fire
+    except ImportError as e:
+        raise ImportError('CLI requires the "cli" extra: pip install "rf100vl[cli]"') from e
+    fire.Fire({"download": download})
+
+
+if __name__ == "__main__":
+    main()

--- a/rf100vl/__main__.py
+++ b/rf100vl/__main__.py
@@ -37,7 +37,7 @@ def download(
 
     dataset: "rf100vl" or "rf20vl"
     fsod: use the few-shot object detection variant
-    index: download only the i-th dataset in the variant, instead of all
+    index: download only the dataset at this zero-based index in the variant, instead of all
     """
     if dataset not in _FULL_DOWNLOADERS:
         raise ValueError(f"unknown dataset {dataset!r}; expected one of {sorted(_FULL_DOWNLOADERS)}")


### PR DESCRIPTION
This pull request adds a command-line interface (CLI) to the `rf100vl` package, allowing users to download datasets directly from the terminal. The CLI supports various flags for customizing downloads, such as selecting dataset variants, formats, and specific indices. It also updates the documentation and package configuration to reflect these new features.

**CLI implementation and integration:**

* Introduced a new CLI entry point in `rf100vl/__main__.py` using the `fire` library, enabling users to download datasets with various options (e.g., variant, index, format, overwrite, API key) directly from the command line.
* Registered the CLI as a script (`rf100vl`) in `pyproject.toml` and added an optional `cli` dependency for `fire`.

**Documentation updates:**

* Updated `README.md` to document the new CLI, including installation instructions, usage examples, and available flags.

**API and import adjustments:**

* Reordered and cleaned up imports in `rf100vl/__init__.py` to ensure correct export order and avoid duplicate imports.

**Minor cleanup:**

* Removed a stray blank line in `README.md` for consistency.