### PR TITLE
feat: enable also combine datasets into one

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 build/
 dist/
 *.egg-info/
+rf100-vl/
+test/datasets/
+.cache/
+.combine_manifest.json

--- a/README.md
+++ b/README.md
@@ -109,6 +109,68 @@ rf100vl download rf20vl ./data --fsod            # RF20-VL-FSOD
 rf100vl download rf100vl ./data --index 0        # first dataset by index
 ```
 
+## Combine Datasets
+
+Fold two or more RF100-VL sub-datasets into a single COCO dataset — one
+unified label space, one set of `train/valid/test` folders — instead of
+training against each dataset separately.
+
+Category labels are namespaced per source dataset (`dataset:label`, e.g.
+`deeppcb:open` vs `stomata-cells:open`) to avoid false-friend collisions
+between datasets that happen to use the same word for different concepts.
+Image filenames are prefixed with their source dataset (`bees_<file>.jpg`)
+so they never collide once combined.
+
+**Two ways to combine, matching two use cases:**
+
+1. **Download + combine in one step** — `download(..., combine=True)` /
+   `rf100vl download ... --combine`. Downloads the selected datasets into
+   `<path>/.cache/` (kept, reused on future calls with an overlapping
+   selection) and writes the combined dataset directly at
+   `<path>/{train,valid,test}`.
+2. **Combine datasets you already downloaded** — `combine_downloaded(...)`
+   / `rf100vl combine`. No network access; operates in place on a
+   directory that already contains per-dataset folders (e.g. from several
+   plain `download` calls). **Destructive by default**: each per-dataset
+   folder (`path/bees`, `path/deeppcb`, ...) is *moved* into the combined
+   tree and removed once empty, so no disk space is duplicated. Pass
+   `keep_originals=True` to copy instead and leave the source folders
+   intact. Interrupted runs are resumable — progress is tracked in
+   `path/.combine_manifest.json`, so re-running skips already-merged
+   datasets instead of redoing them.
+
+Python API:
+
+```python
+from rf100vl import download_and_combine, combine_downloaded
+
+# download 3 datasets by global index and combine them
+download_and_combine("./combined", indices=[0, 15, 29])
+
+# or combine datasets you already downloaded under ./data
+# (./data/bees, ./data/deeppcb, ... get folded into ./data/{train,valid,test})
+combine_downloaded("./data")
+```
+
+CLI:
+
+```
+rf100vl download rf100vl ./combined --combine --indices 0,15,29
+rf100vl combine ./data
+rf100vl combine ./data --names bees,deeppcb --keep-originals
+```
+
+| Flag (`combine`) | Description |
+|------|-------------|
+| `path` | directory of already-downloaded per-dataset folders to combine (positional) |
+| `--indices` | comma-separated global dataset indices to include, e.g. `0,3,7`; mutually exclusive with `--names` |
+| `--names` | comma-separated canonical dataset basenames to include, e.g. `bees,deeppcb`; mutually exclusive with `--indices` |
+| `--keep_originals` | copy instead of move — leaves source per-dataset folders untouched (default: `False`) |
+
+`download`'s `--combine` flag adds `--indices`/`--names` (same meaning as
+above) and requires one of `--index`, `--indices`, or `--names` to pick a
+finite selection; not yet supported together with `--fsod`.
+
 ## CVPR 2025 Workshop Challenge: Few-Shot Object Detection from Annotator Instructions
 
 **Organized by:** Anish Madan, Neehar Peri, Deva Ramanan

--- a/rf100vl/__init__.py
+++ b/rf100vl/__init__.py
@@ -1,4 +1,6 @@
 from rf100vl.roboflow100vl import (
+    combine_downloaded,
+    download_and_combine,
     download_rf100vl,
     download_rf100vl_fsod,
     download_rf100vl_index,
@@ -22,4 +24,6 @@ __all__ = [
     "download_rf20vl_fsod",
     "download_rf20vl_full",
     "download_rf100vl_index",
+    "combine_downloaded",
+    "download_and_combine",
 ]

--- a/rf100vl/__main__.py
+++ b/rf100vl/__main__.py
@@ -27,6 +27,17 @@ _INDEX_VARIANTS = {
 }
 
 
+def _indices_to_basenames(indices: list) -> list:
+    basenames = []
+    n = len(_CANONICAL_BASENAMES)
+    for token in indices:
+        i = int(token)
+        if not 0 <= i < n:
+            raise ValueError(f"index {i} out of range (expected 0..{n - 1})")
+        basenames.append(_CANONICAL_BASENAMES[i])
+    return basenames
+
+
 def _split_csv_flag(value) -> Optional[list]:
     """Normalize a comma-separated CLI flag to a list of str tokens.
 
@@ -71,17 +82,19 @@ def download(
     if dataset not in _FULL_DOWNLOADERS:
         raise ValueError(f"unknown dataset {dataset!r}; expected one of {sorted(_FULL_DOWNLOADERS)}")
 
+    if not combine and (indices is not None or names is not None):
+        raise ValueError("--indices and --names are only valid with --combine")
+
     if combine:
         if fsod:
             raise ValueError("combine is not supported for the fsod variant yet")
-        if indices is not None and names is not None:
-            raise ValueError("pass at most one of --indices or --names")
         split_indices = _split_csv_flag(indices)
         parsed_indices = [int(i) for i in split_indices] if split_indices is not None else None
         parsed_names = _split_csv_flag(names)
-        if parsed_indices is None and parsed_names is None:
-            if index is None:
-                raise ValueError("combine requires one of --index, --indices, or --names")
+        selection_count = int(index is not None) + int(parsed_indices is not None) + int(parsed_names is not None)
+        if selection_count != 1:
+            raise ValueError("combine requires exactly one of --index, --indices, or --names")
+        if index is not None:
             parsed_indices = [index]
         variant = _INDEX_VARIANTS[(dataset, False)]
         download_and_combine(
@@ -143,7 +156,7 @@ def combine(
     basenames = None
     split_indices = _split_csv_flag(indices)
     if split_indices is not None:
-        basenames = [_CANONICAL_BASENAMES[int(i)] for i in split_indices]
+        basenames = _indices_to_basenames(split_indices)
     else:
         basenames = _split_csv_flag(names)
     combine_downloaded(path, basenames=basenames, keep_originals=keep_originals)

--- a/rf100vl/__main__.py
+++ b/rf100vl/__main__.py
@@ -1,12 +1,15 @@
 from typing import Optional
 
 from rf100vl import (
+    combine_downloaded,
+    download_and_combine,
     download_rf100vl,
     download_rf100vl_fsod,
     download_rf100vl_index,
     download_rf20vl_fsod,
     download_rf20vl_full,
 )
+from rf100vl.util import values as _CANONICAL_BASENAMES
 
 _FULL_DOWNLOADERS = {
     "rf100vl": download_rf100vl,
@@ -24,23 +27,73 @@ _INDEX_VARIANTS = {
 }
 
 
+def _split_csv_flag(value) -> Optional[list]:
+    """Normalize a comma-separated CLI flag to a list of str tokens.
+
+    Fire doesn't hand back the raw string: a multi-value flag like
+    `--indices 0,15,29` is parsed into a tuple `(0, 15, 29)` before this
+    function ever sees it, and a single value like `--indices 5` is parsed
+    into a bare `int`. Handle every shape Fire can produce, not just str.
+    """
+    if value is None:
+        return None
+    if isinstance(value, (list, tuple)):
+        return [str(v) for v in value]
+    return [v.strip() for v in str(value).split(",")]
+
+
 def download(
     dataset: str,
     path: str,
     fsod: bool = False,
     index: Optional[int] = None,
+    indices: Optional[str] = None,
+    names: Optional[str] = None,
     model_format: str = "coco",
     overwrite: bool = True,
     api_key: Optional[str] = None,
+    combine: bool = False,
 ) -> None:
     """Download an rf100-vl dataset.
 
     dataset: "rf100vl" or "rf20vl"
     fsod: use the few-shot object detection variant
     index: download only the dataset at this zero-based index in the variant, instead of all
+    indices: comma-separated global indices to download and fold together, e.g. "0,3,7";
+        only valid together with combine=True, mutually exclusive with names
+    names: comma-separated canonical dataset basenames to download and fold together, e.g.
+        "bees,deeppcb"; only valid together with combine=True, mutually exclusive with indices
+    combine: also fold the downloaded dataset(s) into a combined tree at
+        `<path>/{train,valid,test}` after downloading; raw per-dataset downloads are kept
+        under `<path>/.cache/` (reused on future combine calls, not cleaned up automatically).
+        Requires index, indices, or names to pick a finite selection; fsod not supported yet.
     """
     if dataset not in _FULL_DOWNLOADERS:
         raise ValueError(f"unknown dataset {dataset!r}; expected one of {sorted(_FULL_DOWNLOADERS)}")
+
+    if combine:
+        if fsod:
+            raise ValueError("combine is not supported for the fsod variant yet")
+        if indices is not None and names is not None:
+            raise ValueError("pass at most one of --indices or --names")
+        split_indices = _split_csv_flag(indices)
+        parsed_indices = [int(i) for i in split_indices] if split_indices is not None else None
+        parsed_names = _split_csv_flag(names)
+        if parsed_indices is None and parsed_names is None:
+            if index is None:
+                raise ValueError("combine requires one of --index, --indices, or --names")
+            parsed_indices = [index]
+        variant = _INDEX_VARIANTS[(dataset, False)]
+        download_and_combine(
+            path,
+            indices=parsed_indices,
+            names=parsed_names,
+            variant=variant,
+            model_format=model_format,
+            overwrite=overwrite,
+            api_key=api_key,
+        )
+        return
 
     if index is not None:
         variant = _INDEX_VARIANTS[(dataset, fsod)]
@@ -53,12 +106,55 @@ def download(
     downloader(path, model_format=model_format, overwrite=overwrite, api_key=api_key)
 
 
+def combine(
+    path: str,
+    indices: Optional[str] = None,
+    names: Optional[str] = None,
+    keep_originals: bool = False,
+) -> None:
+    """Fold rf100-vl subdatasets already downloaded under `path` into one
+    combined COCO dataset directly at `path/{train,valid,test}`.
+
+    Validates each immediate subdirectory of `path` against the canonical
+    100 rf100-vl dataset names before including it; non-matching or
+    malformed dirs are skipped with a warning. No network access.
+
+    Categories are deduped and dataset-namespaced (`dataset:label`);
+    image/annotation ids are offset per dataset via a stable global index,
+    not selection order, so re-running with a different subset doesn't
+    reshuffle existing ids.
+
+    DESTRUCTIVE BY DEFAULT: per-dataset source folders (e.g. `path/bees`)
+    are moved into the combined tree and removed once empty — not copied.
+    Pass keep_originals=True to copy instead and leave source folders
+    intact. Interruptible and resumable: progress is tracked in
+    `path/.combine_manifest.json`; re-running skips already-merged datasets.
+
+    path: directory containing the per-dataset folders to combine
+    indices: comma-separated global dataset indices to include, e.g. "0,3,7"; mutually
+        exclusive with names; default is every valid dataset found directly under path
+    names: comma-separated canonical dataset basenames to include, e.g. "bees,deeppcb";
+        mutually exclusive with indices
+    keep_originals: copy/hardlink instead of move — leaves source per-dataset folders
+        untouched (default: False, move+remove)
+    """
+    if indices is not None and names is not None:
+        raise ValueError("pass at most one of --indices or --names")
+    basenames = None
+    split_indices = _split_csv_flag(indices)
+    if split_indices is not None:
+        basenames = [_CANONICAL_BASENAMES[int(i)] for i in split_indices]
+    else:
+        basenames = _split_csv_flag(names)
+    combine_downloaded(path, basenames=basenames, keep_originals=keep_originals)
+
+
 def main() -> None:
     try:
         import fire
     except ImportError as e:
         raise ImportError('CLI requires the "cli" extra: pip install "rf100vl[cli]"') from e
-    fire.Fire({"download": download})
+    fire.Fire({"download": download, "combine": combine})
 
 
 if __name__ == "__main__":

--- a/rf100vl/combine.py
+++ b/rf100vl/combine.py
@@ -1,0 +1,317 @@
+"""Fold already-downloaded rf100-vl per-dataset COCO folders into one
+combined dataset, in place, without re-fetching or duplicating images.
+
+Two id schemes, per dataset (see `.plans/active/todo_combine-datasets.md`):
+- image/annotation/license ids: deterministic offset by the dataset's
+  stable global index (`rf100vl.util.get_global_index`), computed
+  per-dataset with no cross-dataset coordination.
+- category ids: map-reduce over every selected dataset's namespaced
+  labels (`f"{basename}:{label}"`), computed once in the join step after
+  every dataset's local categories are known.
+
+Destructive by default: source image files are moved (not copied) into
+the combined tree, and per-dataset folders are removed once emptied.
+Pass `keep_originals=True` to copy instead and leave sources intact.
+Progress is tracked in `<path>/.combine_manifest.json` so an interrupted
+run can resume without re-reading already-consumed source folders.
+"""
+
+import json
+import os
+import shutil
+from typing import Dict, List, Optional, Tuple
+
+from rf100vl.util import get_global_index
+from rf100vl.util import values as CANONICAL_BASENAMES
+
+SPLITS = ("train", "valid", "test")
+IMAGE_STRIDE = 1_000_000
+ANNOTATION_STRIDE = 10_000_000
+_INT32_MAX = 2_147_483_647
+
+MANIFEST_FILENAME = ".combine_manifest.json"
+_SKIP_DIRS = {".cache", "train", "valid", "test"}
+
+
+class CombineError(Exception):
+    pass
+
+
+def find_valid_dataset_dirs(path: str) -> List[str]:
+    """Return canonical basenames of `path`'s immediate subdirectories that
+    look like rf100-vl per-dataset folders (name in the canonical 100-name
+    allowlist, at least one split has `_annotations.coco.json`). Non-matching
+    dirs are skipped with a warning, not raised.
+    """
+    canonical = set(CANONICAL_BASENAMES)
+    found = []
+    for entry in sorted(os.listdir(path)):
+        if entry in _SKIP_DIRS or entry.startswith("."):
+            continue
+        full = os.path.join(path, entry)
+        if not os.path.isdir(full):
+            continue
+        if entry not in canonical:
+            print(f"warning: skipping {entry!r} under {path!r} — not a canonical rf100-vl dataset name")
+            continue
+        if not any(os.path.exists(os.path.join(full, split, "_annotations.coco.json")) for split in SPLITS):
+            print(f"warning: skipping {entry!r} under {path!r} — no split has _annotations.coco.json")
+            continue
+        found.append(entry)
+    return found
+
+
+def _assert_headroom(basename: str, local_ids: List[int], stride: int, global_index: int, label: str) -> None:
+    if local_ids and max(local_ids) >= stride:
+        raise CombineError(f"{basename}: local {label} id {max(local_ids)} >= stride {stride}")
+    if global_index * stride > _INT32_MAX:
+        raise CombineError(f"{basename}: global_index {global_index} * {label} stride {stride} overflows int32")
+
+
+def _remap_split(dataset_dir: str, basename: str, split: str) -> Optional[dict]:
+    """Read + remap one dataset's split annotation file. Returns None if the
+    dataset has no data for this split. Offsets image/annotation/license ids
+    by this dataset's stable global index; namespaces category names
+    (`dataset:label`) without assigning a final id yet (decided globally in
+    the join step, see `_build_category_map`).
+    """
+    ann_path = os.path.join(dataset_dir, split, "_annotations.coco.json")
+    if not os.path.exists(ann_path):
+        return None
+    with open(ann_path) as f:
+        data = json.load(f)
+
+    global_index = get_global_index(basename)
+    image_ids = [img["id"] for img in data["images"]]
+    annotation_ids = [ann["id"] for ann in data["annotations"]]
+    license_ids = [lic["id"] for lic in data.get("licenses", [])]
+    _assert_headroom(basename, image_ids, IMAGE_STRIDE, global_index, "image")
+    _assert_headroom(basename, annotation_ids, ANNOTATION_STRIDE, global_index, "annotation")
+    _assert_headroom(basename, license_ids, IMAGE_STRIDE, global_index, "license")
+
+    image_offset = global_index * IMAGE_STRIDE
+    annotation_offset = global_index * ANNOTATION_STRIDE
+    license_offset = global_index * IMAGE_STRIDE
+
+    images = []
+    for img in data["images"]:
+        new_img = dict(img)
+        new_img["id"] = img["id"] + image_offset
+        if img.get("license") is not None:
+            new_img["license"] = img["license"] + license_offset
+        new_img["_source_file_name"] = img["file_name"]
+        new_img["file_name"] = f"{basename}_{img['file_name']}"
+        images.append(new_img)
+
+    namespaced_by_local_id = {cat["id"]: f"{basename}:{cat['name']}" for cat in data["categories"]}
+    annotations = []
+    for ann in data["annotations"]:
+        new_ann = dict(ann)
+        new_ann["id"] = ann["id"] + annotation_offset
+        new_ann["image_id"] = ann["image_id"] + image_offset
+        new_ann["_namespaced_category"] = namespaced_by_local_id[ann["category_id"]]
+        del new_ann["category_id"]
+        annotations.append(new_ann)
+
+    licenses = [{**lic, "id": lic["id"] + license_offset} for lic in data.get("licenses", [])]
+
+    return {
+        "basename": basename,
+        "images": images,
+        "annotations": annotations,
+        "licenses": licenses,
+        "info": data.get("info"),
+        "categories": data["categories"],
+    }
+
+
+def _build_category_map(fragments: List[dict]) -> Dict[str, int]:
+    """Map-reduce over every selected dataset's namespaced labels: dedupe,
+    sort, id = position. Includes categories with zero annotations too.
+    """
+    labels = set()
+    for frag in fragments:
+        for cat in frag["categories"]:
+            labels.add(f"{frag['basename']}:{cat['name']}")
+    return {label: i for i, label in enumerate(sorted(labels))}
+
+
+def _dedupe_licenses(fragments: List[dict]) -> Tuple[List[dict], Dict[int, int]]:
+    """Dedupe already-offset license entries by (url, name) content. Returns
+    the deduped license list and a map from offset id -> final id.
+    """
+    content_to_id: Dict[Tuple, int] = {}
+    remap: Dict[int, int] = {}
+    deduped: List[dict] = []
+    for frag in fragments:
+        for lic in frag["licenses"]:
+            key = (lic.get("url"), lic.get("name"))
+            if key not in content_to_id:
+                new_id = len(deduped) + 1
+                content_to_id[key] = new_id
+                deduped.append({**lic, "id": new_id})
+            remap[lic["id"]] = content_to_id[key]
+    return deduped, remap
+
+
+def _merge_split(
+    fragments: List[dict],
+    category_map: Dict[str, int],
+    license_remap: Dict[int, int],
+    deduped_licenses: List[dict],
+) -> dict:
+    categories = []
+    for label, cid in sorted(category_map.items(), key=lambda kv: kv[1]):
+        supercategory = label.split(":", 1)[0]
+        categories.append({"id": cid, "name": label, "supercategory": supercategory})
+
+    images: List[dict] = []
+    annotations: List[dict] = []
+    infos: List[dict] = []
+    for frag in fragments:
+        for img in frag["images"]:
+            new_img = {k: v for k, v in img.items() if not k.startswith("_")}
+            if new_img.get("license") is not None:
+                new_img["license"] = license_remap[new_img["license"]]
+            images.append(new_img)
+        for ann in frag["annotations"]:
+            new_ann = {k: v for k, v in ann.items() if not k.startswith("_")}
+            new_ann["category_id"] = category_map[ann["_namespaced_category"]]
+            annotations.append(new_ann)
+        if frag["info"]:
+            infos.append(frag["info"])
+
+    return {
+        "info": infos,
+        "licenses": deduped_licenses,
+        "categories": categories,
+        "images": images,
+        "annotations": annotations,
+    }
+
+
+def _load_manifest(path: str) -> dict:
+    manifest_path = os.path.join(path, MANIFEST_FILENAME)
+    if os.path.exists(manifest_path):
+        with open(manifest_path) as f:
+            return json.load(f)
+    return {"datasets": {}}
+
+
+def _save_manifest(path: str, manifest: dict) -> None:
+    manifest_path = os.path.join(path, MANIFEST_FILENAME)
+    tmp_path = manifest_path + ".tmp"
+    with open(tmp_path, "w") as f:
+        json.dump(manifest, f)
+    os.replace(tmp_path, manifest_path)
+
+
+def _materialize_dataset(path: str, basename: str, fragments: Dict[str, dict], keep_originals: bool) -> None:
+    """Move (or copy) one dataset's images into the combined tree.
+    Idempotent per-file — safe to re-run after a partial interruption:
+    a file already present at its destination is left alone, and a file
+    missing from both source and destination raises loudly instead of
+    silently producing a combined dataset with missing images.
+    """
+    dataset_dir = os.path.join(path, basename)
+    for split, frag in fragments.items():
+        images_dir = os.path.join(path, split, "images")
+        os.makedirs(images_dir, exist_ok=True)
+        for img in frag["images"]:
+            src = os.path.join(dataset_dir, split, img["_source_file_name"])
+            dst = os.path.join(images_dir, img["file_name"])
+            if os.path.exists(dst):
+                continue
+            if not os.path.exists(src):
+                raise CombineError(f"{basename}/{split}: missing both source {src!r} and dest {dst!r}")
+            if keep_originals:
+                shutil.copy2(src, dst)
+            else:
+                shutil.move(src, dst)
+        if not keep_originals:
+            ann_path = os.path.join(dataset_dir, split, "_annotations.coco.json")
+            if os.path.exists(ann_path):
+                os.remove(ann_path)
+
+    if not keep_originals:
+        for split in SPLITS:
+            split_dir = os.path.join(dataset_dir, split)
+            if os.path.isdir(split_dir) and not os.listdir(split_dir):
+                os.rmdir(split_dir)
+        # Roboflow's COCO export always drops these two boilerplate files at
+        # the dataset root (confirmed identical structure across datasets);
+        # safe to remove by name. Anything else unexpected left over still
+        # blocks the final rmdir below rather than being force-deleted.
+        for readme in ("README.roboflow.txt", "README.dataset.txt"):
+            readme_path = os.path.join(dataset_dir, readme)
+            if os.path.exists(readme_path):
+                os.remove(readme_path)
+        if os.path.isdir(dataset_dir) and not os.listdir(dataset_dir):
+            os.rmdir(dataset_dir)
+
+
+def combine(path: str, basenames: Optional[List[str]] = None, keep_originals: bool = False) -> Dict[str, dict]:
+    """Combine already-downloaded per-dataset folders under `path` into one
+    dataset directly at `path/{train,valid,test}`. Returns the combined
+    per-split COCO dicts (also written to disk).
+
+    `basenames`: which per-dataset folders to include; default is every
+    valid one found directly under `path` (see `find_valid_dataset_dirs`).
+    """
+    selected = basenames if basenames is not None else find_valid_dataset_dirs(path)
+    if not selected:
+        raise CombineError(f"no valid rf100-vl dataset folders found under {path!r}")
+    invalid = sorted(set(selected) - set(CANONICAL_BASENAMES))
+    if invalid:
+        raise CombineError(f"not canonical rf100-vl dataset names: {invalid}")
+
+    manifest = _load_manifest(path)
+    datasets_cache = manifest.setdefault("datasets", {})
+
+    for basename in selected:
+        entry = datasets_cache.get(basename)
+        if entry is not None and entry.get("materialized"):
+            continue
+
+        if entry is None:
+            dataset_dir = os.path.join(path, basename)
+            fragments = {}
+            for split in SPLITS:
+                frag = _remap_split(dataset_dir, basename, split)
+                if frag is not None:
+                    fragments[split] = frag
+            entry = {"fragments": fragments, "materialized": False}
+            datasets_cache[basename] = entry
+            _save_manifest(path, manifest)
+
+        _materialize_dataset(path, basename, entry["fragments"], keep_originals)
+        entry["materialized"] = True
+        _save_manifest(path, manifest)
+
+    # Join over every materialized dataset in the manifest, not just
+    # `selected` — a prior run's dataset may no longer exist as a directory
+    # (already moved+removed) so it wouldn't be rediscovered by a default
+    # directory scan, but its images already live under path/{split}/images/
+    # and must stay referenced in the combined json or they'd be orphaned.
+    combined_basenames = sorted(b for b, entry in datasets_cache.items() if entry.get("materialized"))
+    all_fragments = [
+        datasets_cache[b]["fragments"][s] for b in combined_basenames for s in SPLITS if s in datasets_cache[b]["fragments"]
+    ]
+    category_map = _build_category_map(all_fragments)
+    deduped_licenses, license_remap = _dedupe_licenses(all_fragments)
+
+    combined_by_split: Dict[str, dict] = {}
+    for split in SPLITS:
+        split_fragments = [
+            datasets_cache[b]["fragments"][split] for b in combined_basenames if split in datasets_cache[b]["fragments"]
+        ]
+        if not split_fragments:
+            continue
+        combined = _merge_split(split_fragments, category_map, license_remap, deduped_licenses)
+        combined_by_split[split] = combined
+        out_dir = os.path.join(path, split)
+        os.makedirs(out_dir, exist_ok=True)
+        with open(os.path.join(out_dir, "_annotations.coco.json"), "w") as f:
+            json.dump(combined, f)
+
+    return combined_by_split

--- a/rf100vl/combine.py
+++ b/rf100vl/combine.py
@@ -181,8 +181,13 @@ def _merge_split(
         if frag["info"]:
             infos.append(frag["info"])
 
+    info: dict = {}
+    if infos:
+        info = dict(infos[0]) if isinstance(infos[0], dict) else {}
+        info["rf100vl_source_info"] = infos
+
     return {
-        "info": infos,
+        "info": info,
         "licenses": deduped_licenses,
         "categories": categories,
         "images": images,
@@ -273,6 +278,7 @@ def combine(
     (Flow A) — implies `keep_originals` so the cache survives for reuse.
     """
     out_path = out_path or path
+    os.makedirs(out_path, exist_ok=True)
     selected = basenames if basenames is not None else find_valid_dataset_dirs(path)
     if not selected:
         raise CombineError(f"no valid rf100-vl dataset folders found under {path!r}")

--- a/rf100vl/combine.py
+++ b/rf100vl/combine.py
@@ -206,16 +206,21 @@ def _save_manifest(path: str, manifest: dict) -> None:
     os.replace(tmp_path, manifest_path)
 
 
-def _materialize_dataset(path: str, basename: str, fragments: Dict[str, dict], keep_originals: bool) -> None:
-    """Move (or copy) one dataset's images into the combined tree.
-    Idempotent per-file — safe to re-run after a partial interruption:
-    a file already present at its destination is left alone, and a file
-    missing from both source and destination raises loudly instead of
-    silently producing a combined dataset with missing images.
+def _materialize_dataset(
+    path: str, out_path: str, basename: str, fragments: Dict[str, dict], keep_originals: bool
+) -> None:
+    """Move (or copy) one dataset's images from `path/<basename>` into the
+    combined tree at `out_path`. Idempotent per-file — safe to re-run after
+    a partial interruption: a file already present at its destination is
+    left alone, and a file missing from both source and destination raises
+    loudly instead of silently producing a combined dataset with missing
+    images. `keep_originals` implies copy — always true when `path !=
+    out_path` (Flow A: source lives under `.cache`, must survive for reuse).
     """
     dataset_dir = os.path.join(path, basename)
+    keep_originals = keep_originals or path != out_path
     for split, frag in fragments.items():
-        images_dir = os.path.join(path, split, "images")
+        images_dir = os.path.join(out_path, split, "images")
         os.makedirs(images_dir, exist_ok=True)
         for img in frag["images"]:
             src = os.path.join(dataset_dir, split, img["_source_file_name"])
@@ -250,14 +255,24 @@ def _materialize_dataset(path: str, basename: str, fragments: Dict[str, dict], k
             os.rmdir(dataset_dir)
 
 
-def combine(path: str, basenames: Optional[List[str]] = None, keep_originals: bool = False) -> Dict[str, dict]:
-    """Combine already-downloaded per-dataset folders under `path` into one
-    dataset directly at `path/{train,valid,test}`. Returns the combined
-    per-split COCO dicts (also written to disk).
+def combine(
+    path: str,
+    basenames: Optional[List[str]] = None,
+    keep_originals: bool = False,
+    out_path: Optional[str] = None,
+) -> Dict[str, dict]:
+    """Combine per-dataset folders found under `path` into one dataset at
+    `out_path/{train,valid,test}`. Returns the combined per-split COCO
+    dicts (also written to disk).
 
     `basenames`: which per-dataset folders to include; default is every
     valid one found directly under `path` (see `find_valid_dataset_dirs`).
+    `out_path`: defaults to `path` (Flow B: true in-place combine). Pass a
+    different `out_path` to read sources from one directory (e.g. a
+    `.cache/` of raw downloads) while writing the combined tree elsewhere
+    (Flow A) — implies `keep_originals` so the cache survives for reuse.
     """
+    out_path = out_path or path
     selected = basenames if basenames is not None else find_valid_dataset_dirs(path)
     if not selected:
         raise CombineError(f"no valid rf100-vl dataset folders found under {path!r}")
@@ -265,7 +280,7 @@ def combine(path: str, basenames: Optional[List[str]] = None, keep_originals: bo
     if invalid:
         raise CombineError(f"not canonical rf100-vl dataset names: {invalid}")
 
-    manifest = _load_manifest(path)
+    manifest = _load_manifest(out_path)
     datasets_cache = manifest.setdefault("datasets", {})
 
     for basename in selected:
@@ -282,11 +297,11 @@ def combine(path: str, basenames: Optional[List[str]] = None, keep_originals: bo
                     fragments[split] = frag
             entry = {"fragments": fragments, "materialized": False}
             datasets_cache[basename] = entry
-            _save_manifest(path, manifest)
+            _save_manifest(out_path, manifest)
 
-        _materialize_dataset(path, basename, entry["fragments"], keep_originals)
+        _materialize_dataset(path, out_path, basename, entry["fragments"], keep_originals)
         entry["materialized"] = True
-        _save_manifest(path, manifest)
+        _save_manifest(out_path, manifest)
 
     # Join over every materialized dataset in the manifest, not just
     # `selected` — a prior run's dataset may no longer exist as a directory
@@ -309,7 +324,7 @@ def combine(path: str, basenames: Optional[List[str]] = None, keep_originals: bo
             continue
         combined = _merge_split(split_fragments, category_map, license_remap, deduped_licenses)
         combined_by_split[split] = combined
-        out_dir = os.path.join(path, split)
+        out_dir = os.path.join(out_path, split)
         os.makedirs(out_dir, exist_ok=True)
         with open(os.path.join(out_dir, "_annotations.coco.json"), "w") as f:
             json.dump(combined, f)

--- a/rf100vl/combine.py
+++ b/rf100vl/combine.py
@@ -290,11 +290,15 @@ def combine(
 
         if entry is None:
             dataset_dir = os.path.join(path, basename)
+            if not os.path.isdir(dataset_dir):
+                raise CombineError(f"{basename}: no such directory {dataset_dir!r}")
             fragments = {}
             for split in SPLITS:
                 frag = _remap_split(dataset_dir, basename, split)
                 if frag is not None:
                     fragments[split] = frag
+            if not fragments:
+                raise CombineError(f"{basename}: no split has _annotations.coco.json under {dataset_dir!r}")
             entry = {"fragments": fragments, "materialized": False}
             datasets_cache[basename] = entry
             _save_manifest(out_path, manifest)

--- a/rf100vl/roboflow100vl.py
+++ b/rf100vl/roboflow100vl.py
@@ -1,4 +1,5 @@
 import os
+import json
 from typing import Dict, List, Optional, Iterator
 from rf100vl.dataset import RF100VlDataset
 from rf100vl.combine import combine as run_combine
@@ -197,12 +198,57 @@ def _resolve_datasets_for_combine(
         raise ValueError(f"unknown variant {variant!r}; expected one of {sorted(_PROJECT_FETCHERS)}")
     all_datasets = fetcher(api_key)
     if indices is not None:
+        n = len(all_datasets)
+        for i in indices:
+            if not 0 <= i < n:
+                raise IndexError(f"variant {variant!r} has {n} datasets; index {i} out of range")
         return [all_datasets[i] for i in indices]
     by_name = {d.name: d for d in all_datasets}
     missing = [n for n in names if n not in by_name]
     if missing:
         raise ValueError(f"unknown dataset name(s) for variant {variant!r}: {missing}")
     return [by_name[n] for n in names]
+
+
+def _load_combine_manifest(path: str) -> dict:
+    manifest_path = os.path.join(path, ".combine_manifest.json")
+    if not os.path.exists(manifest_path):
+        return {"datasets": {}}
+    with open(manifest_path) as f:
+        return json.load(f)
+
+
+def _save_combine_manifest(path: str, manifest: dict) -> None:
+    os.makedirs(path, exist_ok=True)
+    manifest_path = os.path.join(path, ".combine_manifest.json")
+    tmp_path = manifest_path + ".tmp"
+    with open(tmp_path, "w") as f:
+        json.dump(manifest, f)
+    os.replace(tmp_path, manifest_path)
+
+
+def _dataset_cache_complete(cache_dir: str, basename: str) -> bool:
+    dataset_dir = os.path.join(cache_dir, basename)
+    if not os.path.isdir(dataset_dir):
+        return False
+    return any(
+        os.path.exists(os.path.join(dataset_dir, split, "_annotations.coco.json"))
+        for split in ("train", "valid", "test")
+    )
+
+
+def _invalidate_materialized_dataset(path: str, manifest: dict, basename: str) -> None:
+    datasets_cache = manifest.get("datasets", {})
+    entry = datasets_cache.get(basename)
+    if not entry or not entry.get("materialized"):
+        return
+    for split, frag in entry.get("fragments", {}).items():
+        images_dir = os.path.join(path, split, "images")
+        for img in frag.get("images", []):
+            image_path = os.path.join(images_dir, img["file_name"])
+            if os.path.exists(image_path):
+                os.remove(image_path)
+    del datasets_cache[basename]
 
 
 def download_and_combine(
@@ -228,7 +274,24 @@ def download_and_combine(
     datasets = _resolve_datasets_for_combine(indices, names, variant, api_key)
     cache_dir = os.path.join(path, ".cache")
     os.makedirs(cache_dir, exist_ok=True)
+    manifest = _load_combine_manifest(path)
+    datasets_cache = manifest.get("datasets", {})
+    manifest_dirty = False
     for dataset in datasets:
-        dataset.download(os.path.join(cache_dir, dataset.name), model_format=model_format, overwrite=overwrite)
+        entry = datasets_cache.get(dataset.name)
+        materialized = bool(entry and entry.get("materialized"))
+        if overwrite and materialized:
+            _invalidate_materialized_dataset(path, manifest, dataset.name)
+            entry = None
+            materialized = False
+            manifest_dirty = True
+        cache_complete = _dataset_cache_complete(cache_dir, dataset.name)
+        should_download = overwrite or not cache_complete
+        if materialized and not overwrite:
+            should_download = False
+        if should_download:
+            dataset.download(os.path.join(cache_dir, dataset.name), model_format=model_format, overwrite=overwrite)
+    if manifest_dirty:
+        _save_combine_manifest(path, manifest)
     basenames = [dataset.name for dataset in datasets]
     return run_combine(cache_dir, basenames=basenames, out_path=path)

--- a/rf100vl/roboflow100vl.py
+++ b/rf100vl/roboflow100vl.py
@@ -1,6 +1,7 @@
 import os
-from typing import List, Optional, Iterator
+from typing import Dict, List, Optional, Iterator
 from rf100vl.dataset import RF100VlDataset
+from rf100vl.combine import combine as run_combine
 from roboflow import Project
 import roboflow
 
@@ -161,3 +162,73 @@ def download_rf100vl_index(
     dataset = get_rf100vl_dataset_by_index(index, variant=variant, api_key=api_key)
     dataset.download(path, model_format=model_format, overwrite=overwrite)
     return dataset
+
+
+# ---------------------------------------------------------------------------
+# Combine — fold per-dataset COCO folders into one dataset. See
+# rf100vl/combine.py for the actual remap/merge/move logic and
+# .plans/active/todo_combine-datasets.md for the design.
+# ---------------------------------------------------------------------------
+
+
+def combine_downloaded(path: str, basenames: Optional[List[str]] = None, keep_originals: bool = False) -> Dict[str, dict]:
+    """Fold per-dataset folders already downloaded under ``path`` into one
+    combined COCO dataset directly at ``path/{train,valid,test}`` — no
+    network access. Thin wrapper over ``rf100vl.combine.combine`` (Flow B,
+    in-place). Destructive by default: source folders are moved and
+    removed once empty; pass ``keep_originals=True`` to copy instead.
+
+    ``basenames``: which per-dataset folders to include; default is every
+    valid one found directly under ``path``.
+    """
+    return run_combine(path, basenames=basenames, keep_originals=keep_originals)
+
+
+def _resolve_datasets_for_combine(
+    indices: Optional[List[int]],
+    names: Optional[List[str]],
+    variant: str,
+    api_key: Optional[str],
+) -> List[RF100VlDataset]:
+    if (indices is None) == (names is None):
+        raise ValueError("pass exactly one of `indices` or `names`")
+    fetcher = _PROJECT_FETCHERS.get(variant)
+    if fetcher is None:
+        raise ValueError(f"unknown variant {variant!r}; expected one of {sorted(_PROJECT_FETCHERS)}")
+    all_datasets = fetcher(api_key)
+    if indices is not None:
+        return [all_datasets[i] for i in indices]
+    by_name = {d.name: d for d in all_datasets}
+    missing = [n for n in names if n not in by_name]
+    if missing:
+        raise ValueError(f"unknown dataset name(s) for variant {variant!r}: {missing}")
+    return [by_name[n] for n in names]
+
+
+def download_and_combine(
+    path: str,
+    indices: Optional[List[int]] = None,
+    names: Optional[List[str]] = None,
+    *,
+    variant: str = "rf100vl",
+    model_format: str = "coco",
+    overwrite: bool = True,
+    api_key: Optional[str] = None,
+) -> Dict[str, dict]:
+    """Download the selected dataset(s) and fold them into one combined COCO
+    tree directly at ``path/{train,valid,test}``. Raw per-dataset downloads
+    land under ``path/.cache/`` and are kept (not cleaned up) so a later
+    call with an overlapping selection can reuse them (Flow A).
+
+    Pass exactly one of ``indices`` (global indices into the sorted
+    variant) or ``names`` (canonical basenames).
+    """
+    if model_format != "coco":
+        raise ValueError(f"combine only supports model_format='coco', got {model_format!r}")
+    datasets = _resolve_datasets_for_combine(indices, names, variant, api_key)
+    cache_dir = os.path.join(path, ".cache")
+    os.makedirs(cache_dir, exist_ok=True)
+    for dataset in datasets:
+        dataset.download(os.path.join(cache_dir, dataset.name), model_format=model_format, overwrite=overwrite)
+    basenames = [dataset.name for dataset in datasets]
+    return run_combine(cache_dir, basenames=basenames, out_path=path)

--- a/rf100vl/roboflow100vl.py
+++ b/rf100vl/roboflow100vl.py
@@ -18,9 +18,8 @@ def get_rf(api_key: Optional[str] = None):
 
 class DatasetList:
     def __init__(self, projects: List[Project]):
-        self.projects = projects
-        self.projects = sorted(self.projects, key=lambda p: p.name)
-        self.datasets = [RF100VlDataset(p) for p in projects]
+        self.projects = sorted(projects, key=lambda p: p.name)
+        self.datasets = [RF100VlDataset(p) for p in self.projects]
 
     def __iter__(self) -> Iterator[RF100VlDataset]:
         return iter(self.datasets)

--- a/rf100vl/util.py
+++ b/rf100vl/util.py
@@ -27,3 +27,12 @@ def get_category(dataset_name: str):
 
 def get_basename(dataset_name: str):
     return DATASET_TO_BASENAME_JSON[dataset_name]
+
+# Stable global rank per canonical basename (0..99), independent of selection
+# order, download state, or DatasetList's sort. Derived from `values` (already
+# the sorted canonical basename list above) rather than a new asset file, so
+# there is one source of truth for the 100-dataset name list.
+BASENAME_TO_GLOBAL_INDEX = {name: i for i, name in enumerate(values)}
+
+def get_global_index(basename: str) -> int:
+    return BASENAME_TO_GLOBAL_INDEX[basename]

--- a/test/test_combine.py
+++ b/test/test_combine.py
@@ -138,6 +138,8 @@ class TestCombineEndToEnd:
         moved_files = os.listdir(corpus_copy / "train" / "images")
         assert any(f.startswith("jellyfish_") for f in moved_files)
         assert any(f.startswith("deeppcb_") for f in moved_files)
+        assert isinstance(result["train"]["info"], dict)
+        assert "rf100vl_source_info" in result["train"]["info"]
 
     @requires_local_corpus
     def test_keep_originals_copies_instead_of_moves(self, corpus_copy):
@@ -181,6 +183,14 @@ class TestCombineEndToEnd:
         with pytest.raises(CombineError):
             combine(str(tmp_path), basenames=["bees"])
 
+    @requires_local_corpus
+    def test_out_path_is_created_before_manifest_write(self, corpus_copy):
+        out_path = corpus_copy / "combined"
+
+        combine(str(corpus_copy), basenames=["jellyfish"], out_path=str(out_path))
+
+        assert os.path.exists(out_path / ".combine_manifest.json")
+
 
 class TestCombineDownloaded:
     @requires_local_corpus
@@ -205,6 +215,16 @@ class _FakeDataset:
         shutil.copytree(self._source_dir, path, dirs_exist_ok=True)
 
 
+class _CountingFakeDataset(_FakeDataset):
+    def __init__(self, name, source_dir):
+        super().__init__(name, source_dir)
+        self.download_calls = 0
+
+    def download(self, path, model_format="coco", overwrite=True):
+        self.download_calls += 1
+        super().download(path, model_format=model_format, overwrite=overwrite)
+
+
 class TestResolveDatasetsForCombine:
     def test_requires_exactly_one_of_indices_or_names(self):
         """Passing both or neither indices/names is a hard error, not an ambiguous default."""
@@ -215,6 +235,12 @@ class TestResolveDatasetsForCombine:
         """An unsupported variant name fails loudly instead of silently no-oping."""
         with pytest.raises(ValueError):
             roboflow100vl._resolve_datasets_for_combine([0], None, "not-a-real-variant", None)
+
+    def test_indices_validate_non_negative(self, monkeypatch):
+        monkeypatch.setitem(roboflow100vl._PROJECT_FETCHERS, "rf100vl", lambda api_key=None: [_FakeDataset("bees", "")])
+
+        with pytest.raises(IndexError):
+            roboflow100vl._resolve_datasets_for_combine([-1], None, "rf100vl", None)
 
 
 class TestDownloadAndCombine:
@@ -237,6 +263,16 @@ class TestDownloadAndCombine:
         assert os.path.exists(tmp_path / ".cache" / "deeppcb" / "train" / "_annotations.coco.json")
         assert os.path.exists(tmp_path / "train" / "_annotations.coco.json")
         assert len(result["train"]["images"]) > 0
+
+    @requires_local_corpus
+    def test_reuses_materialized_entry_without_redownload(self, tmp_path, monkeypatch):
+        fake = _CountingFakeDataset("jellyfish", os.path.join(_LOCAL_CORPUS, "jellyfish"))
+        monkeypatch.setitem(roboflow100vl._PROJECT_FETCHERS, "rf100vl", lambda api_key=None: [fake])
+
+        roboflow100vl.download_and_combine(str(tmp_path), names=["jellyfish"], overwrite=False)
+        roboflow100vl.download_and_combine(str(tmp_path), names=["jellyfish"], overwrite=False)
+
+        assert fake.download_calls == 1
 
 
 class TestSplitCsvFlag:
@@ -300,6 +336,10 @@ class TestCLICombine:
         with pytest.raises(ValueError):
             cli.combine(str(tmp_path), indices="0", names="bees")
 
+    def test_negative_indices_are_rejected(self, tmp_path):
+        with pytest.raises(ValueError):
+            cli.combine(str(tmp_path), indices="-1")
+
 
 class TestCLIDownloadCombine:
     def test_combine_requires_a_selection(self, tmp_path):
@@ -317,6 +357,20 @@ class TestCLIDownloadCombine:
         """Passing both --indices and --names with --combine is a hard error."""
         with pytest.raises(ValueError):
             cli.download("rf100vl", str(tmp_path), combine=True, indices="0", names="bees")
+
+    def test_indices_require_combine(self, tmp_path):
+        with pytest.raises(ValueError):
+            cli.download("rf100vl", str(tmp_path), indices="0")
+
+    def test_names_require_combine(self, tmp_path):
+        with pytest.raises(ValueError):
+            cli.download("rf100vl", str(tmp_path), names="bees")
+
+    def test_combine_selection_is_strictly_mutually_exclusive(self, tmp_path):
+        with pytest.raises(ValueError):
+            cli.download("rf100vl", str(tmp_path), combine=True, index=0, indices="0")
+        with pytest.raises(ValueError):
+            cli.download("rf100vl", str(tmp_path), combine=True, index=0, names="bees")
 
     @requires_local_corpus
     def test_combine_wires_through_to_download_and_combine(self, tmp_path, monkeypatch):

--- a/test/test_combine.py
+++ b/test/test_combine.py
@@ -1,0 +1,172 @@
+"""Tests for rf100vl.combine — pure remap/merge helpers and the destructive
+end-to-end combine() flow, run against throwaway copies of the two smallest
+local datasets (jellyfish, deeppcb) so a bug can never touch the real
+40GB corpus.
+"""
+
+import json
+import os
+import shutil
+
+import pytest
+
+from rf100vl import combine as combine_mod
+from rf100vl.combine import CombineError, combine, find_valid_dataset_dirs
+from rf100vl.util import get_global_index
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_LOCAL_CORPUS = os.path.join(_REPO_ROOT, "rf100-vl")
+_FIXTURE_DATASETS = ("jellyfish", "deeppcb")
+
+
+def _fixtures_available() -> bool:
+    return all(
+        os.path.exists(os.path.join(_LOCAL_CORPUS, name, "train", "_annotations.coco.json"))
+        for name in _FIXTURE_DATASETS
+    )
+
+
+requires_local_corpus = pytest.mark.skipif(
+    not _fixtures_available(), reason="local rf100-vl corpus not present (jellyfish/deeppcb)"
+)
+
+
+@pytest.fixture
+def corpus_copy(tmp_path):
+    """Copy jellyfish + deeppcb into an isolated tmp dir so destructive
+    combine() runs never touch the real local corpus.
+    """
+    for name in _FIXTURE_DATASETS:
+        shutil.copytree(os.path.join(_LOCAL_CORPUS, name), tmp_path / name)
+    return tmp_path
+
+
+class TestFindValidDatasetDirs:
+    @requires_local_corpus
+    def test_finds_canonical_dataset_dirs(self, corpus_copy):
+        """Both copied fixture datasets are recognized as valid."""
+        found = find_valid_dataset_dirs(str(corpus_copy))
+
+        assert sorted(found) == sorted(_FIXTURE_DATASETS)
+
+    def test_skips_non_canonical_dir(self, tmp_path):
+        """A dir whose name isn't one of the 100 canonical basenames is skipped."""
+        os.makedirs(tmp_path / "not-a-real-dataset" / "train")
+
+        found = find_valid_dataset_dirs(str(tmp_path))
+
+        assert found == []
+
+    def test_skips_own_output_dirs(self, tmp_path):
+        """`.cache`, `train`, `valid`, `test` are always skipped, even if present."""
+        for name in (".cache", "train", "valid", "test"):
+            os.makedirs(tmp_path / name)
+
+        found = find_valid_dataset_dirs(str(tmp_path))
+
+        assert found == []
+
+
+class TestBuildCategoryMap:
+    def test_namespaces_and_dedupes_labels(self):
+        """Same label string in two datasets stays two distinct namespaced ids."""
+        fragments = [
+            {"basename": "deeppcb", "categories": [{"name": "open"}, {"name": "short"}]},
+            {"basename": "stomata-cells", "categories": [{"name": "open"}]},
+        ]
+
+        category_map = combine_mod._build_category_map(fragments)
+
+        assert set(category_map) == {"deeppcb:open", "deeppcb:short", "stomata-cells:open"}
+        assert category_map["deeppcb:open"] != category_map["stomata-cells:open"]
+
+    def test_ids_are_sorted_position(self):
+        """global_category_id is the position of the label in sorted order."""
+        fragments = [{"basename": "z", "categories": [{"name": "b"}]}, {"basename": "a", "categories": [{"name": "b"}]}]
+
+        category_map = combine_mod._build_category_map(fragments)
+
+        assert category_map == {"a:b": 0, "z:b": 1}
+
+
+class TestAssertHeadroom:
+    @pytest.mark.parametrize(
+        "local_ids,stride,global_index",
+        [
+            pytest.param([0, 1, 5], 5, 0, id="local-id-exceeds-stride"),
+            pytest.param([0], 1_000_000, 3000, id="global-index-overflows-int32"),
+        ],
+    )
+    def test_raises_on_overflow(self, local_ids, stride, global_index):
+        """Both overflow conditions (local id headroom, int32 ceiling) raise, not silently collide."""
+        with pytest.raises(CombineError):
+            combine_mod._assert_headroom("ds", local_ids, stride, global_index, "image")
+
+    def test_passes_within_headroom(self):
+        """Real observed max (8791 images) stays under IMAGE_STRIDE with room to spare."""
+        combine_mod._assert_headroom("bees", [8791], combine_mod.IMAGE_STRIDE, get_global_index("bees"), "image")
+
+
+class TestCombineEndToEnd:
+    @requires_local_corpus
+    def test_combines_two_datasets(self, corpus_copy):
+        """Images move into path/{split}/images/, source dirs are removed,
+        combined json has correct totals and namespaced categories."""
+        jelly_json = json.load(open(corpus_copy / "jellyfish" / "train" / "_annotations.coco.json"))
+        pcb_json = json.load(open(corpus_copy / "deeppcb" / "train" / "_annotations.coco.json"))
+        expected_images = len(jelly_json["images"]) + len(pcb_json["images"])
+        expected_anns = len(jelly_json["annotations"]) + len(pcb_json["annotations"])
+
+        result = combine(str(corpus_copy))
+
+        assert len(result["train"]["images"]) == expected_images
+        assert len(result["train"]["annotations"]) == expected_anns
+        assert set(c["name"] for c in result["train"]["categories"]) == {
+            "jellyfish:Jellyfish",
+            "deeppcb:copper",
+            "deeppcb:mousebite",
+            "deeppcb:open",
+            "deeppcb:pin-hole",
+            "deeppcb:short",
+            "deeppcb:spur",
+        }
+        assert not os.path.exists(corpus_copy / "jellyfish")
+        assert not os.path.exists(corpus_copy / "deeppcb")
+        assert os.path.exists(corpus_copy / "train" / "images")
+        moved_files = os.listdir(corpus_copy / "train" / "images")
+        assert any(f.startswith("jellyfish_") for f in moved_files)
+        assert any(f.startswith("deeppcb_") for f in moved_files)
+
+    @requires_local_corpus
+    def test_keep_originals_copies_instead_of_moves(self, corpus_copy):
+        """keep_originals=True leaves source per-dataset folders intact."""
+        combine(str(corpus_copy), keep_originals=True)
+
+        assert os.path.exists(corpus_copy / "jellyfish" / "train" / "_annotations.coco.json")
+        assert os.path.exists(corpus_copy / "deeppcb" / "train" / "_annotations.coco.json")
+        assert os.path.exists(corpus_copy / "train" / "images")
+
+    @requires_local_corpus
+    def test_resume_skips_already_materialized_dataset(self, corpus_copy):
+        """A dataset already combined in a prior run is not reprocessed --
+        the manifest lets a second call add the remaining dataset only."""
+        combine(str(corpus_copy), basenames=["jellyfish"])
+        assert not os.path.exists(corpus_copy / "jellyfish")
+        assert os.path.exists(corpus_copy / "deeppcb")
+
+        result = combine(str(corpus_copy))
+
+        assert not os.path.exists(corpus_copy / "deeppcb")
+        assert any(name.startswith("jellyfish:") for name in [c["name"] for c in result["train"]["categories"]])
+        assert any(name.startswith("deeppcb:") for name in [c["name"] for c in result["train"]["categories"]])
+
+    def test_raises_on_no_valid_datasets(self, tmp_path):
+        """Empty/non-matching path is a hard error, not a silent no-op."""
+        with pytest.raises(CombineError):
+            combine(str(tmp_path))
+
+    def test_raises_on_non_canonical_basename(self, tmp_path):
+        """Explicitly passing a non-canonical name is a hard error."""
+        os.makedirs(tmp_path / "totally-not-real")
+        with pytest.raises(CombineError):
+            combine(str(tmp_path), basenames=["totally-not-real"])

--- a/test/test_combine.py
+++ b/test/test_combine.py
@@ -10,6 +10,7 @@ import shutil
 
 import pytest
 
+from rf100vl import __main__ as cli
 from rf100vl import combine as combine_mod
 from rf100vl import roboflow100vl
 from rf100vl.combine import CombineError, combine, find_valid_dataset_dirs
@@ -172,6 +173,14 @@ class TestCombineEndToEnd:
         with pytest.raises(CombineError):
             combine(str(tmp_path), basenames=["totally-not-real"])
 
+    def test_raises_on_explicit_basename_with_no_directory(self, tmp_path):
+        """A canonical basename with no matching directory under path must
+        raise, not silently return an empty result with no error -- an
+        earlier version of this code did exactly that.
+        """
+        with pytest.raises(CombineError):
+            combine(str(tmp_path), basenames=["bees"])
+
 
 class TestCombineDownloaded:
     @requires_local_corpus
@@ -228,3 +237,113 @@ class TestDownloadAndCombine:
         assert os.path.exists(tmp_path / ".cache" / "deeppcb" / "train" / "_annotations.coco.json")
         assert os.path.exists(tmp_path / "train" / "_annotations.coco.json")
         assert len(result["train"]["images"]) > 0
+
+
+class TestSplitCsvFlag:
+    """Fire hands back different Python types depending on the flag value's
+    shape, not always the raw string -- a bug (`'tuple' object has no
+    attribute 'split'`) shipped because tests called cli functions
+    directly with plain strings and never exercised this.
+    """
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            pytest.param(None, None, id="none"),
+            pytest.param("0,15,29", ["0", "15", "29"], id="str-multi"),
+            pytest.param("5", ["5"], id="str-single"),
+            pytest.param((0, 15, 29), ["0", "15", "29"], id="fire-tuple-multi"),
+            pytest.param(5, ["5"], id="fire-bare-int-single"),
+        ],
+    )
+    def test_normalizes_every_shape_fire_can_produce(self, value, expected):
+        assert cli._split_csv_flag(value) == expected
+
+
+class TestCLICombine:
+    @requires_local_corpus
+    def test_names_resolve_and_combine(self, corpus_copy):
+        """`rf100vl combine --names` resolves directly to basenames."""
+        cli.combine(str(corpus_copy), names="jellyfish,deeppcb")
+
+        assert not os.path.exists(corpus_copy / "jellyfish")
+        assert os.path.exists(corpus_copy / "train" / "_annotations.coco.json")
+
+    @requires_local_corpus
+    def test_indices_resolve_to_basenames(self, corpus_copy):
+        """`rf100vl combine --indices` resolves global indices to basenames
+        via the same canonical list used by get_global_index."""
+        jelly_idx = get_global_index("jellyfish")
+        pcb_idx = get_global_index("deeppcb")
+
+        cli.combine(str(corpus_copy), indices=f"{jelly_idx},{pcb_idx}")
+
+        assert not os.path.exists(corpus_copy / "jellyfish")
+        assert not os.path.exists(corpus_copy / "deeppcb")
+
+    @requires_local_corpus
+    def test_indices_as_fire_parsed_tuple(self, corpus_copy):
+        """Regression test for the actual reported crash: Fire parses
+        `--indices 0,15,29` into a tuple of ints before combine() ever
+        sees it, not the comma-separated string `.split(",")` assumed.
+        """
+        jelly_idx = get_global_index("jellyfish")
+        pcb_idx = get_global_index("deeppcb")
+
+        cli.combine(str(corpus_copy), indices=(jelly_idx, pcb_idx))
+
+        assert not os.path.exists(corpus_copy / "jellyfish")
+        assert not os.path.exists(corpus_copy / "deeppcb")
+
+    def test_indices_and_names_mutually_exclusive(self, tmp_path):
+        """Passing both --indices and --names is a hard error."""
+        with pytest.raises(ValueError):
+            cli.combine(str(tmp_path), indices="0", names="bees")
+
+
+class TestCLIDownloadCombine:
+    def test_combine_requires_a_selection(self, tmp_path):
+        """--combine with no --index/--indices/--names is a hard error, not
+        an implicit "combine all 100 datasets"."""
+        with pytest.raises(ValueError):
+            cli.download("rf100vl", str(tmp_path), combine=True)
+
+    def test_combine_rejects_fsod(self, tmp_path):
+        """--combine + --fsod is unsupported for now, fails loudly."""
+        with pytest.raises(ValueError):
+            cli.download("rf100vl", str(tmp_path), fsod=True, combine=True, index=0)
+
+    def test_combine_indices_and_names_mutually_exclusive(self, tmp_path):
+        """Passing both --indices and --names with --combine is a hard error."""
+        with pytest.raises(ValueError):
+            cli.download("rf100vl", str(tmp_path), combine=True, indices="0", names="bees")
+
+    @requires_local_corpus
+    def test_combine_wires_through_to_download_and_combine(self, tmp_path, monkeypatch):
+        """`rf100vl download --combine --names=...` downloads (faked, no
+        network) into path/.cache/ and writes the combined tree at path/.
+        """
+        fakes = [
+            _FakeDataset("jellyfish", os.path.join(_LOCAL_CORPUS, "jellyfish")),
+            _FakeDataset("deeppcb", os.path.join(_LOCAL_CORPUS, "deeppcb")),
+        ]
+        monkeypatch.setitem(roboflow100vl._PROJECT_FETCHERS, "rf100vl", lambda api_key=None: fakes)
+
+        cli.download("rf100vl", str(tmp_path), combine=True, names="jellyfish,deeppcb")
+
+        assert os.path.exists(tmp_path / ".cache" / "jellyfish" / "train" / "_annotations.coco.json")
+        assert os.path.exists(tmp_path / "train" / "_annotations.coco.json")
+
+    @requires_local_corpus
+    def test_combine_indices_as_fire_parsed_tuple(self, tmp_path, monkeypatch):
+        """Same regression as TestCLICombine.test_indices_as_fire_parsed_tuple,
+        for the download --combine --indices path."""
+        fakes = [
+            _FakeDataset("jellyfish", os.path.join(_LOCAL_CORPUS, "jellyfish")),
+            _FakeDataset("deeppcb", os.path.join(_LOCAL_CORPUS, "deeppcb")),
+        ]
+        monkeypatch.setitem(roboflow100vl._PROJECT_FETCHERS, "rf100vl", lambda api_key=None: fakes)
+
+        cli.download("rf100vl", str(tmp_path), combine=True, indices=(0, 1))
+
+        assert os.path.exists(tmp_path / "train" / "_annotations.coco.json")

--- a/test/test_combine.py
+++ b/test/test_combine.py
@@ -11,6 +11,7 @@ import shutil
 import pytest
 
 from rf100vl import combine as combine_mod
+from rf100vl import roboflow100vl
 from rf100vl.combine import CombineError, combine, find_valid_dataset_dirs
 from rf100vl.util import get_global_index
 
@@ -170,3 +171,60 @@ class TestCombineEndToEnd:
         os.makedirs(tmp_path / "totally-not-real")
         with pytest.raises(CombineError):
             combine(str(tmp_path), basenames=["totally-not-real"])
+
+
+class TestCombineDownloaded:
+    @requires_local_corpus
+    def test_thin_wrapper_over_combine(self, corpus_copy):
+        """combine_downloaded delegates to combine() with the same semantics."""
+        result = roboflow100vl.combine_downloaded(str(corpus_copy))
+
+        assert not os.path.exists(corpus_copy / "jellyfish")
+        assert len(result["train"]["images"]) > 0
+
+
+class _FakeDataset:
+    """Stands in for RF100VlDataset in download_and_combine wiring tests --
+    `.download()` copies from a local fixture instead of hitting the network.
+    """
+
+    def __init__(self, name, source_dir):
+        self.name = name
+        self._source_dir = source_dir
+
+    def download(self, path, model_format="coco", overwrite=True):
+        shutil.copytree(self._source_dir, path, dirs_exist_ok=True)
+
+
+class TestResolveDatasetsForCombine:
+    def test_requires_exactly_one_of_indices_or_names(self):
+        """Passing both or neither indices/names is a hard error, not an ambiguous default."""
+        with pytest.raises(ValueError):
+            roboflow100vl._resolve_datasets_for_combine(None, None, "rf100vl", None)
+
+    def test_unknown_variant_raises(self):
+        """An unsupported variant name fails loudly instead of silently no-oping."""
+        with pytest.raises(ValueError):
+            roboflow100vl._resolve_datasets_for_combine([0], None, "not-a-real-variant", None)
+
+
+class TestDownloadAndCombine:
+    @requires_local_corpus
+    def test_downloads_into_cache_and_combines_at_top_level(self, tmp_path, monkeypatch):
+        """Raw downloads land under path/.cache/<name>/ and survive (Flow A
+        always keeps originals); combined tree is written at path/ directly.
+        No real network call -- RF100VlDataset.download is faked to copy
+        from the local jellyfish/deeppcb fixtures.
+        """
+        fakes = [
+            _FakeDataset("jellyfish", os.path.join(_LOCAL_CORPUS, "jellyfish")),
+            _FakeDataset("deeppcb", os.path.join(_LOCAL_CORPUS, "deeppcb")),
+        ]
+        monkeypatch.setitem(roboflow100vl._PROJECT_FETCHERS, "rf100vl", lambda api_key=None: fakes)
+
+        result = roboflow100vl.download_and_combine(str(tmp_path), names=["jellyfish", "deeppcb"])
+
+        assert os.path.exists(tmp_path / ".cache" / "jellyfish" / "train" / "_annotations.coco.json")
+        assert os.path.exists(tmp_path / ".cache" / "deeppcb" / "train" / "_annotations.coco.json")
+        assert os.path.exists(tmp_path / "train" / "_annotations.coco.json")
+        assert len(result["train"]["images"]) > 0


### PR DESCRIPTION
This pull request introduces robust support for combining multiple rf100-vl per-dataset COCO folders into a single unified dataset. It adds both a standalone `combine` function and CLI command, as well as integrated workflows to download and combine selected datasets in one step. The implementation ensures deterministic ID remapping, category namespacing, and safe, resumable operations, with options to move or copy source data. The most important changes are summarized below:

**New combine functionality:**

* Added a new module `rf100vl/combine.py` implementing the logic to merge multiple per-dataset COCO folders into a single dataset, with deterministic ID offsets, category namespacing, deduplication of licenses, and manifest-tracked progress for resumability. Supports both destructive (move) and non-destructive (copy) modes.
* Exposed `combine_downloaded` and `download_and_combine` functions in `rf100vl/roboflow100vl.py` as thin wrappers over the new combine logic, enabling both in-place combination and download-then-combine workflows.

**CLI and API enhancements:**

* Updated `rf100vl/__main__.py` to add a new `combine` CLI command and extend the `download` command with `--combine`, `--indices`, and `--names` options, allowing users to specify which datasets to combine by index or name and to combine immediately after download. [[1]](diffhunk://#diff-14cb4ed2a698f9fc28d115388be06f4a01a2735426beaa31f24aac9c5b333e2aR4-R12) [[2]](diffhunk://#diff-14cb4ed2a698f9fc28d115388be06f4a01a2735426beaa31f24aac9c5b333e2aR35-R81) [[3]](diffhunk://#diff-14cb4ed2a698f9fc28d115388be06f4a01a2735426beaa31f24aac9c5b333e2aR93-R140)
* Updated `rf100vl/__init__.py` to expose the new combine-related functions in the public API. [[1]](diffhunk://#diff-09a43ffaa9e1e2b43488f293857884afcb5009922badc245031415dee34ed40bR2-R3) [[2]](diffhunk://#diff-09a43ffaa9e1e2b43488f293857884afcb5009922badc245031415dee34ed40bR27-R28)

**Supporting changes and bugfixes:**

* Fixed sorting and initialization in `DatasetList` to ensure datasets are always sorted by name.

These changes collectively provide a flexible, efficient, and user-friendly way to manage and combine rf100-vl datasets for downstream tasks.